### PR TITLE
Field Orientation

### DIFF
--- a/src/main/java/frc/robot/CalculateRedValues.java
+++ b/src/main/java/frc/robot/CalculateRedValues.java
@@ -1,0 +1,45 @@
+package frc.robot;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class CalculateRedValues {
+
+    public static void main(String[] args) throws IOException {
+        AprilTagFieldLayout field = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile);
+
+        System.out.println("Length:" + field.getFieldLength());
+        System.out.println("Width: " + field.getFieldWidth());
+
+        HashMap<String, Pose2d> things = new HashMap<>();
+        things.put("cSpeakerPark",  new Pose2d(1.4, 5.54, Rotation2d.fromDegrees(0)));
+        things.put("cSpeakerPose",  new Pose2d(0, 5.55, Rotation2d.fromDegrees(180)));
+        things.put("cPickupPark",  new Pose2d(15.25, 1.2, Rotation2d.fromDegrees(-60)));
+        things.put("cAmpPark",  new Pose2d(1.84, 7.5, Rotation2d.fromDegrees(-90)));
+        things.put("cLeftStagePark",  new Pose2d(4.5, 5, Rotation2d.fromDegrees(300)));
+        things.put("cCenterStagePark",  new Pose2d(5.8, 4.5, Rotation2d.fromDegrees(180)));
+        things.put("cRightStagePark",  new Pose2d(4.5, 3.5, Rotation2d.fromDegrees(60)));
+        things.put("cTopCloseRing1",  new Pose2d(2.89, 7, Rotation2d.fromDegrees(0)));
+        things.put("cMidCloseRing2",  new Pose2d(2.89, 5.55, Rotation2d.fromDegrees(0)));
+        things.put("cBotCloseRing3",  new Pose2d(2.89, 4.11, Rotation2d.fromDegrees(0)));
+        things.put("cFarRing4",  new Pose2d(8.28, 7.44, Rotation2d.fromDegrees(0)));
+        things.put("cFarRing5",  new Pose2d(8.28, 5.78, Rotation2d.fromDegrees(0)));
+        things.put("cFarRing6",  new Pose2d(8.28, 4.11, Rotation2d.fromDegrees(0)));
+        things.put("cFarRing7",  new Pose2d(8.28, 2.44, Rotation2d.fromDegrees(0)));
+        things.put("cFarRing8",  new Pose2d(8.28, 0.77, Rotation2d.fromDegrees(0)));
+        things.put("nothingPose",  new Pose2d(69, 420, Rotation2d.fromDegrees(0)));
+
+        for(String position : things.keySet()){
+            System.out.println(position);
+            Pose2d p = things.get(position);
+            System.out.println(new Pose2d(field.getFieldLength() - p.getX(), p.getY(), p.getRotation().rotateBy(Rotation2d.fromDegrees(180))));
+        }
+
+    }
+
+}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,26 +61,27 @@ public final class Constants
     public static final double cDriveDeadband = 0.15;
     public static final double cTurnDeadband = 0.15;
 
-    public static final Pose2d cSpeakerPark = new Pose2d(1.4, 5.54, Rotation2d.fromDegrees(0));
-    public static final Pose2d cSpeakerPose = new Pose2d(0, 5.55, Rotation2d.fromDegrees(180));
-    public static final Pose2d cPickupPark = new Pose2d(15.25, 1.2, Rotation2d.fromDegrees(-60));
-    public static final Pose2d cAmpPark = new Pose2d(1.84, 7.5, Rotation2d.fromDegrees(-90));
-
-    public static final Pose2d cLeftStagePark = new Pose2d(4.5, 5, Rotation2d.fromDegrees(300));
-    public static final Pose2d cCenterStagePark = new Pose2d(5.8, 4.5, Rotation2d.fromDegrees(180));
-    public static final Pose2d cRightStagePark = new Pose2d(4.5, 3.5, Rotation2d.fromDegrees(60));
-    public static final Pose2d cTopCloseRing1 = new Pose2d(2.89, 7, Rotation2d.fromDegrees(0));
-    public static final Pose2d cMidCloseRing2 = new Pose2d(2.89, 5.55, Rotation2d.fromDegrees(0));
-    public static final Pose2d cBotCloseRing3 = new Pose2d(2.89, 4.11, Rotation2d.fromDegrees(0));
-    public static final Pose2d cFarRing4 = new Pose2d(8.28, 7.44, Rotation2d.fromDegrees(0));
-    public static final Pose2d cFarRing5 = new Pose2d(8.28, 5.78, Rotation2d.fromDegrees(0));
-    public static final Pose2d cFarRing6 = new Pose2d(8.28, 4.11, Rotation2d.fromDegrees(0));
-    public static final Pose2d cFarRing7 = new Pose2d(8.28, 2.44, Rotation2d.fromDegrees(0));
-    public static final Pose2d cFarRing8 = new Pose2d(8.28, 0.77, Rotation2d.fromDegrees(0));
-    public static final Pose2d nothingPose = new Pose2d(69, 420, Rotation2d.fromDegrees(0));
-
-    //TODO set these values :)
-    public static final Pose2d cSpeakerTargetPos = new Pose2d(0, 5.55, Rotation2d.fromDegrees(0));
+    //If you want to use these, check out FieldOrientation and RobotContainer for how it's used.
+//    public static final Pose2d cSpeakerPark = new Pose2d(1.4, 5.54, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cSpeakerPose = new Pose2d(0, 5.55, Rotation2d.fromDegrees(180));
+//    public static final Pose2d cPickupPark = new Pose2d(15.25, 1.2, Rotation2d.fromDegrees(-60));
+//    public static final Pose2d cAmpPark = new Pose2d(1.84, 7.5, Rotation2d.fromDegrees(-90));
+//
+//    public static final Pose2d cLeftStagePark = new Pose2d(4.5, 5, Rotation2d.fromDegrees(300));
+//    public static final Pose2d cCenterStagePark = new Pose2d(5.8, 4.5, Rotation2d.fromDegrees(180));
+//    public static final Pose2d cRightStagePark = new Pose2d(4.5, 3.5, Rotation2d.fromDegrees(60));
+//    public static final Pose2d cTopCloseRing1 = new Pose2d(2.89, 7, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cMidCloseRing2 = new Pose2d(2.89, 5.55, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cBotCloseRing3 = new Pose2d(2.89, 4.11, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cFarRing4 = new Pose2d(8.28, 7.44, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cFarRing5 = new Pose2d(8.28, 5.78, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cFarRing6 = new Pose2d(8.28, 4.11, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cFarRing7 = new Pose2d(8.28, 2.44, Rotation2d.fromDegrees(0));
+//    public static final Pose2d cFarRing8 = new Pose2d(8.28, 0.77, Rotation2d.fromDegrees(0));
+//    public static final Pose2d nothingPose = new Pose2d(69, 420, Rotation2d.fromDegrees(0));
+//
+//    //TODO set these values :)
+//    public static final Pose2d cSpeakerTargetPos = new Pose2d(0, 5.55, Rotation2d.fromDegrees(0));
     public static final double cSpeakerTargetHeight = 0;
     public static final double cMotorVeltoDistance = 100;
     public static final double cMotorVeltoExitVel = 1;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -11,6 +11,8 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
+import static frc.robot.positioning.FieldOrientation.getOrientation;
+
 /**
  * The VM is configured to automatically run this class, and to call the methods corresponding to
  * each mode, as described in the TimedRobot documentation. If you change the name of this class or
@@ -52,6 +54,9 @@ public class Robot extends TimedRobot
         // commands, running already-scheduled commands, removing finished or interrupted commands,
         // and running subsystem periodic() methods.  This must be called from the robot's periodic
         // block in order for anything in the Command-based framework to work.
+
+        robotContainer.setupAutoTab();
+
         CommandScheduler.getInstance().run();
     }
     

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
-
+import static frc.robot.positioning.FieldOrientation.getOrientation;
 import static frc.robot.Constants.*;
 
 
@@ -98,17 +98,23 @@ public class RobotContainer
 
         new Trigger(xbox::getAButton).whileTrue(new AutoPickupRing(localizationSubsystem, swerveSubsystem));
 
-        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(cPickupPark));
+//        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(cPickupPark));
+        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(getOrientation().getPickupPark()));
 
-        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(cSpeakerPark));
+//        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(cSpeakerPark));
+        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(getOrientation().getSpeakerPark()));
 
-        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(cAmpPark));
+//        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(cAmpPark));
+        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(getOrientation().getAmpPark()));
 
-        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(cCenterStagePark));
+//        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(cCenterStagePark));
+        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(getOrientation().getCenterStagePark()));
 
-        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(cRightStagePark));
+//        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(cRightStagePark));
+        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(getOrientation().getRightStagePark()));
 
-        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(cLeftStagePark));
+//        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(cLeftStagePark));
+        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(getOrientation().getLeftStagePark()));
 
         //test
         new Trigger(xbox::getYButton).whileTrue(new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem));
@@ -190,15 +196,24 @@ public class RobotContainer
         for(int i = 0; i < 8; i++) {
             autoOptions.add(i, new SendableChooser<Pose2d>());
 
-            autoOptions.get(i).setDefaultOption("Nothing", nothingPose);
-            autoOptions.get(i).addOption("Top Close Ring 1", cTopCloseRing1);
-            autoOptions.get(i).addOption("Mid Close Ring 2", cMidCloseRing2);
-            autoOptions.get(i).addOption("Bot Close Ring 3", cBotCloseRing3);
-            autoOptions.get(i).addOption("Top Far Ring 4", cFarRing4);
-            autoOptions.get(i).addOption("Mid Top Far Ring 5", cFarRing5);
-            autoOptions.get(i).addOption("Mid Far Ring 6", cFarRing6);
-            autoOptions.get(i).addOption("Mid Bot Far Ring 7", cFarRing7);
-            autoOptions.get(i).addOption("Bot Far Ring 8", cFarRing8);
+//            autoOptions.get(i).setDefaultOption("Nothing", nothingPose);
+            autoOptions.get(i).setDefaultOption("Nothing", getOrientation().getNothingPose());
+//            autoOptions.get(i).addOption("Top Close Ring 1", cTopCloseRing1);
+            autoOptions.get(i).addOption("Top Close Ring 1", getOrientation().getTopCloseRing());
+//            autoOptions.get(i).addOption("Mid Close Ring 2", cMidCloseRing2);
+            autoOptions.get(i).addOption("Mid Close Ring 2", getOrientation().getMidCloseRing());
+//            autoOptions.get(i).addOption("Bot Close Ring 3", cBotCloseRing3);
+            autoOptions.get(i).addOption("Bot Close Ring 3", getOrientation().getBotCloseRing());
+//            autoOptions.get(i).addOption("Top Far Ring 4", cFarRing4);
+            autoOptions.get(i).addOption("Top Far Ring 4", getOrientation().getFarRing4());
+//            autoOptions.get(i).addOption("Mid Top Far Ring 5", cFarRing5);
+            autoOptions.get(i).addOption("Mid Top Far Ring 5", getOrientation().getFarRing5());
+//            autoOptions.get(i).addOption("Mid Far Ring 6", cFarRing6);
+            autoOptions.get(i).addOption("Mid Far Ring 6", getOrientation().getFarRing6());
+//            autoOptions.get(i).addOption("Mid Bot Far Ring 7", cFarRing7);
+            autoOptions.get(i).addOption("Mid Bot Far Ring 7", getOrientation().getFarRing7());
+//            autoOptions.get(i).addOption("Bot Far Ring 8", cFarRing8);
+            autoOptions.get(i).addOption("Bot Far Ring 8", getOrientation().getFarRing8());
             //autoOptions[i].addOption("End Location", new Pose2d(endX, endY, Rotation2d.fromDegrees(endRotation)));
 
             autoTab.add("Auto " + i, autoOptions.get(i)).withWidget(BuiltInWidgets.kComboBoxChooser)
@@ -254,7 +269,7 @@ public class RobotContainer
         Pose2d endLoc = new Pose2d(endX.get(), endY.get(), Rotation2d.fromDegrees(endRotation.get()));
 
         for (int i = 0; i < 8; i++) {
-            if (autoOptions.get(i).getSelected() != nothingPose) {
+            if (autoOptions.get(i).getSelected() != getOrientation().getNothingPose()) {
                 autoRings++;
             }
         }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,6 +23,8 @@ import frc.robot.commands.*;
 import frc.robot.commands.TargetSpeakerCommand;
 import frc.robot.commands.TeleopDriveCommand;
 import frc.robot.commands.PathWithStopDistance;
+import frc.robot.positioning.FieldOrientation;
+import frc.robot.positioning.Orientation;
 import frc.robot.subsystems.*;
 
 import java.io.File;
@@ -99,22 +101,22 @@ public class RobotContainer
         new Trigger(xbox::getAButton).whileTrue(new AutoPickupRing(localizationSubsystem, swerveSubsystem));
 
 //        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(cPickupPark));
-        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(getOrientation().getPickupPark()));
+        new Trigger(xbox::getXButton).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(cSpeakerPark));
-        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(getOrientation().getSpeakerPark()));
+        new Trigger(xbox::getLeftBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(cAmpPark));
-        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(getOrientation().getAmpPark()));
+        new Trigger(xbox::getRightBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(cCenterStagePark));
-        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(getOrientation().getCenterStagePark()));
+        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(cRightStagePark));
-        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(getOrientation().getRightStagePark()));
+        new Trigger(() -> xbox.getPOV() == 90).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(cLeftStagePark));
-        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(getOrientation().getLeftStagePark()));
+        new Trigger(() -> xbox.getPOV() == 270).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
         //test
         new Trigger(xbox::getYButton).whileTrue(new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem));
@@ -183,6 +185,7 @@ public class RobotContainer
         field.setRobotPose(new Pose2d(endX.get(), endY.get(), Rotation2d.fromDegrees(endRotation.get())));
     }
 
+    //TODO - Relies on getOrientation, which might not be initialized
     private void setupAutoTab() {
         ShuffleboardTab autoTab = Shuffleboard.getTab("auto");
 
@@ -262,6 +265,7 @@ public class RobotContainer
      *
      * @return the command to run in autonomous
      */
+    //TODO - Relies on getOrientation, which might not be initialized
     public Command getAutonomousCommand()
     {
         boolean endPose = false;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -45,6 +45,8 @@ import static frc.robot.Constants.*;
 public class RobotContainer
 {
 
+    private boolean autoInitialized = false;
+
     private final XboxController xbox = new XboxController(1);
 
     public final ArmSubsystem armSubsystem = new ArmSubsystem();
@@ -100,24 +102,23 @@ public class RobotContainer
 
         new Trigger(xbox::getAButton).whileTrue(new AutoPickupRing(localizationSubsystem, swerveSubsystem));
 
-        //TODO - Fill in with the right command
 //        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(cPickupPark));
         new Trigger(xbox::getXButton).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 
 //        new Trigger(xbox::getLeftBumper).whileTrue(localizationSubsystem.buildPath(cSpeakerPark));
-        new Trigger(xbox::getLeftBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
+        new Trigger(xbox::getLeftBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getSpeakerPark, localizationSubsystem));
 
 //        new Trigger(xbox::getRightBumper).whileTrue(localizationSubsystem.buildPath(cAmpPark));
-        new Trigger(xbox::getRightBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
+        new Trigger(xbox::getRightBumper).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getAmpPark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(localizationSubsystem.buildPath(cCenterStagePark));
-        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
+        new Trigger(() -> xbox.getPOV() == 0).or(() -> xbox.getPOV() == 180).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getCenterStagePark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 90).whileTrue(localizationSubsystem.buildPath(cRightStagePark));
-        new Trigger(() -> xbox.getPOV() == 90).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
+        new Trigger(() -> xbox.getPOV() == 90).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getRightStagePark, localizationSubsystem));
 
 //        new Trigger(() -> xbox.getPOV() == 270).whileTrue(localizationSubsystem.buildPath(cLeftStagePark));
-        new Trigger(() -> xbox.getPOV() == 270).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
+        new Trigger(() -> xbox.getPOV() == 270).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getLeftStagePark, localizationSubsystem));
 
         //test
         new Trigger(xbox::getYButton).whileTrue(new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem));
@@ -178,75 +179,77 @@ public class RobotContainer
 //        new Trigger(() -> joystick.getRawButton(8)).whileTrue(new IntakeTestCommand(shooterSubsystem, -1));
 
         CommandScheduler.getInstance().setDefaultCommand(swerveSubsystem, teleopDriveCommand);
-
-        setupAutoTab();
     }
 
     public void updateField() {
         field.setRobotPose(new Pose2d(endX.get(), endY.get(), Rotation2d.fromDegrees(endRotation.get())));
     }
 
-    //TODO - Relies on getOrientation, which might not be initialized
-    private void setupAutoTab() {
-        ShuffleboardTab autoTab = Shuffleboard.getTab("auto");
+    public void setupAutoTab() {
+        if (!autoInitialized && getOrientation().isValid()) {
 
-        autoOptions = new ArrayList<SendableChooser<Pose2d>>();
+            autoInitialized = true;
 
-        autoRings = 0;
+            ShuffleboardTab autoTab = Shuffleboard.getTab("auto");
 
-        int widgetX = 0;
-        int widgetY = 0;
+            autoOptions = new ArrayList<SendableChooser<Pose2d>>();
 
-        for(int i = 0; i < 8; i++) {
-            autoOptions.add(i, new SendableChooser<Pose2d>());
+            autoRings = 0;
+
+            int widgetX = 0;
+            int widgetY = 0;
+
+            for (int i = 0; i < 8; i++) {
+                autoOptions.add(i, new SendableChooser<Pose2d>());
 
 //            autoOptions.get(i).setDefaultOption("Nothing", nothingPose);
-            autoOptions.get(i).setDefaultOption("Nothing", getOrientation().getNothingPose());
+                autoOptions.get(i).setDefaultOption("Nothing", getOrientation().getNothingPose());
 //            autoOptions.get(i).addOption("Top Close Ring 1", cTopCloseRing1);
-            autoOptions.get(i).addOption("Top Close Ring 1", getOrientation().getTopCloseRing());
+                autoOptions.get(i).addOption("Top Close Ring 1", getOrientation().getTopCloseRing());
 //            autoOptions.get(i).addOption("Mid Close Ring 2", cMidCloseRing2);
-            autoOptions.get(i).addOption("Mid Close Ring 2", getOrientation().getMidCloseRing());
+                autoOptions.get(i).addOption("Mid Close Ring 2", getOrientation().getMidCloseRing());
 //            autoOptions.get(i).addOption("Bot Close Ring 3", cBotCloseRing3);
-            autoOptions.get(i).addOption("Bot Close Ring 3", getOrientation().getBotCloseRing());
+                autoOptions.get(i).addOption("Bot Close Ring 3", getOrientation().getBotCloseRing());
 //            autoOptions.get(i).addOption("Top Far Ring 4", cFarRing4);
-            autoOptions.get(i).addOption("Top Far Ring 4", getOrientation().getFarRing4());
+                autoOptions.get(i).addOption("Top Far Ring 4", getOrientation().getFarRing4());
 //            autoOptions.get(i).addOption("Mid Top Far Ring 5", cFarRing5);
-            autoOptions.get(i).addOption("Mid Top Far Ring 5", getOrientation().getFarRing5());
+                autoOptions.get(i).addOption("Mid Top Far Ring 5", getOrientation().getFarRing5());
 //            autoOptions.get(i).addOption("Mid Far Ring 6", cFarRing6);
-            autoOptions.get(i).addOption("Mid Far Ring 6", getOrientation().getFarRing6());
+                autoOptions.get(i).addOption("Mid Far Ring 6", getOrientation().getFarRing6());
 //            autoOptions.get(i).addOption("Mid Bot Far Ring 7", cFarRing7);
-            autoOptions.get(i).addOption("Mid Bot Far Ring 7", getOrientation().getFarRing7());
+                autoOptions.get(i).addOption("Mid Bot Far Ring 7", getOrientation().getFarRing7());
 //            autoOptions.get(i).addOption("Bot Far Ring 8", cFarRing8);
-            autoOptions.get(i).addOption("Bot Far Ring 8", getOrientation().getFarRing8());
-            //autoOptions[i].addOption("End Location", new Pose2d(endX, endY, Rotation2d.fromDegrees(endRotation)));
+                autoOptions.get(i).addOption("Bot Far Ring 8", getOrientation().getFarRing8());
+                //autoOptions[i].addOption("End Location", new Pose2d(endX, endY, Rotation2d.fromDegrees(endRotation)));
 
-            autoTab.add("Auto " + i, autoOptions.get(i)).withWidget(BuiltInWidgets.kComboBoxChooser)
-                    .withSize(2, 1).withPosition(widgetX, widgetY);
+                autoTab.add("Auto " + i, autoOptions.get(i)).withWidget(BuiltInWidgets.kComboBoxChooser)
+                        .withSize(2, 1).withPosition(widgetX, widgetY);
 
-            widgetX += 2;
-            if (widgetX == 8) {
-                widgetY += 1;
-                widgetX = 0;
+                widgetX += 2;
+                if (widgetX == 8) {
+                    widgetY += 1;
+                    widgetX = 0;
+                }
             }
+
+            var x = autoTab.add("End X", 0)
+                    .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 16.5))
+                    .withSize(2, 1).withPosition(3, 2);
+
+            var y = autoTab.add("End Y", 0)
+                    .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 8.15))
+                    .withSize(2, 1).withPosition(3, 3);
+
+            var rot = autoTab.add("End Rotation", 0)
+                    .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", -180, "max", 180))
+                    .withSize(2, 1).withPosition(5, 2);
+
+            endX = () -> x.getEntry().getDouble(0);
+            endY = () -> y.getEntry().getDouble(0);
+            endRotation = () -> rot.getEntry().getDouble(0);
+
+            autoTab.add(field).withSize(3, 2).withPosition(0, 2);
         }
-
-        var x = autoTab.add("End X", 0)
-                .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 16.5))
-                .withSize(2, 1).withPosition(3, 2);
-
-        var y = autoTab.add("End Y", 0)
-                .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 8.15))
-                .withSize(2, 1).withPosition(3, 3);
-
-        var rot = autoTab.add("End Rotation", 0)
-                .withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", -180, "max", 180))
-                .withSize(2, 1).withPosition(5, 2);
-
-        endX = () -> x.getEntry().getDouble(0);
-        endY = () -> y.getEntry().getDouble(0);
-        endRotation = () -> rot.getEntry().getDouble(0);
-
-        autoTab.add(field).withSize(3, 2).withPosition(0, 2);
     }
     
     

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -269,7 +269,6 @@ public class RobotContainer
      *
      * @return the command to run in autonomous
      */
-    //TODO - Relies on getOrientation, which might not be initialized
     public Command getAutonomousCommand()
     {
         boolean endPose = false;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -100,6 +100,7 @@ public class RobotContainer
 
         new Trigger(xbox::getAButton).whileTrue(new AutoPickupRing(localizationSubsystem, swerveSubsystem));
 
+        //TODO - Fill in with the right command
 //        new Trigger(xbox::getXButton).whileTrue(localizationSubsystem.buildPath(cPickupPark));
         new Trigger(xbox::getXButton).whileTrue(new PathCommand(FieldOrientation::getOrientation, Orientation::getPickupPark, localizationSubsystem));
 

--- a/src/main/java/frc/robot/commands/AutoCommandGroup.java
+++ b/src/main/java/frc/robot/commands/AutoCommandGroup.java
@@ -34,33 +34,35 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 
         this.ringCount = ringCount;
 
-        addCommands(new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem),
-                new AimSpeakerCommandGroup(armSubsystem),
-                //new HomeSequenceCommandGroup(armSubsystem),
-                new NoteShootCommandGroup(shooterSubsystem).deadlineWith());
-                localizationSubsystem.buildPath(new Pose2d(1.5, 5.57, Rotation2d.fromDegrees(0)));
+        if(getOrientation().isValid()) {
+            addCommands(new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem),
+                    new AimSpeakerCommandGroup(armSubsystem),
+                    //new HomeSequenceCommandGroup(armSubsystem),
+                    new NoteShootCommandGroup(shooterSubsystem).deadlineWith());
+            localizationSubsystem.buildPath(new Pose2d(1.5, 5.57, Rotation2d.fromDegrees(0)));
 
-        //TODO - Relies on getOrientation, which might not be initialized
-        for(int i = 0; i < ringCount; i++) {
-            Pose2d ring = rings[i];
-            if (ring != getOrientation().getNothingPose()) {
-                addCommands(
-                        new PathWithStopDistance(localizationSubsystem, ring, 1.5, false)
-                                .onlyIf(() -> ring.getTranslation().getDistance(localizationSubsystem.getCurrentPose().getTranslation()) > 2),
-                        new TurnToCommand(localizationSubsystem, swerveSubsystem, ring),
-                        new AutoPickupRingSequence(armSubsystem, shooterSubsystem,
-                                localizationSubsystem, swerveSubsystem),
-                        Commands.sequence(
+            for (int i = 0; i < ringCount; i++) {
+                Pose2d ring = rings[i];
+                if (ring != getOrientation().getNothingPose()) {
+                    addCommands(
+                            new PathWithStopDistance(localizationSubsystem, ring, 1.5, false)
+                                    .onlyIf(() -> ring.getTranslation().getDistance(localizationSubsystem.getCurrentPose().getTranslation()) > 2),
+                            new TurnToCommand(localizationSubsystem, swerveSubsystem, ring),
+                            new AutoPickupRingSequence(armSubsystem, shooterSubsystem,
+                                    localizationSubsystem, swerveSubsystem),
+                            Commands.sequence(
 //                                localizationSubsystem.buildPath(Constants.cSpeakerPark),
-                                localizationSubsystem.buildPath(getOrientation().getSpeakerPark()),
-                                new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem)/*.onlyIf(() -> shooterSubsystem.getHasRing()*/),
-                                new AimSpeakerCommandGroup(armSubsystem),
-                                new NoteShootCommandGroup(shooterSubsystem));
+                                    localizationSubsystem.buildPath(getOrientation().getSpeakerPark()),
+                                    new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem)/*.onlyIf(() -> shooterSubsystem.getHasRing()*/),
+                            new AimSpeakerCommandGroup(armSubsystem),
+                            new NoteShootCommandGroup(shooterSubsystem));
+                }
             }
+            //end pose
+            addCommands(localizationSubsystem.buildPath(endPose));
         }
-        //end pose
-        addCommands(localizationSubsystem.buildPath(endPose));
+        else {
+            System.err.println("ERROR: AUTO FAILED, INVALID ROBOT ORIENTATION\nRobot might be in Narnia for all I know");
+        }
     }
-
-
 }

--- a/src/main/java/frc/robot/commands/AutoCommandGroup.java
+++ b/src/main/java/frc/robot/commands/AutoCommandGroup.java
@@ -40,6 +40,7 @@ public class AutoCommandGroup extends SequentialCommandGroup {
                 new NoteShootCommandGroup(shooterSubsystem).deadlineWith());
                 localizationSubsystem.buildPath(new Pose2d(1.5, 5.57, Rotation2d.fromDegrees(0)));
 
+        //TODO - Relies on getOrientation, which might not be initialized
         for(int i = 0; i < ringCount; i++) {
             Pose2d ring = rings[i];
             if (ring != getOrientation().getNothingPose()) {

--- a/src/main/java/frc/robot/commands/AutoCommandGroup.java
+++ b/src/main/java/frc/robot/commands/AutoCommandGroup.java
@@ -10,6 +10,7 @@ import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.LocalizationSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 import frc.robot.subsystems.SwerveSubsystem;
+import static frc.robot.positioning.FieldOrientation.getOrientation;
 
 public class AutoCommandGroup extends SequentialCommandGroup {
 
@@ -41,7 +42,7 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 
         for(int i = 0; i < ringCount; i++) {
             Pose2d ring = rings[i];
-            if (ring != Constants.nothingPose) {
+            if (ring != getOrientation().getNothingPose()) {
                 addCommands(
                         new PathWithStopDistance(localizationSubsystem, ring, 1.5, false)
                                 .onlyIf(() -> ring.getTranslation().getDistance(localizationSubsystem.getCurrentPose().getTranslation()) > 2),
@@ -49,7 +50,8 @@ public class AutoCommandGroup extends SequentialCommandGroup {
                         new AutoPickupRingSequence(armSubsystem, shooterSubsystem,
                                 localizationSubsystem, swerveSubsystem),
                         Commands.sequence(
-                                localizationSubsystem.buildPath(Constants.cSpeakerPark),
+//                                localizationSubsystem.buildPath(Constants.cSpeakerPark),
+                                localizationSubsystem.buildPath(getOrientation().getSpeakerPark()),
                                 new TargetSpeakerCommand(swerveSubsystem, localizationSubsystem)/*.onlyIf(() -> shooterSubsystem.getHasRing()*/),
                                 new AimSpeakerCommandGroup(armSubsystem),
                                 new NoteShootCommandGroup(shooterSubsystem));

--- a/src/main/java/frc/robot/commands/IntakeSequenceCommandGroup.java
+++ b/src/main/java/frc/robot/commands/IntakeSequenceCommandGroup.java
@@ -24,4 +24,3 @@ public class IntakeSequenceCommandGroup extends SequentialCommandGroup {
         return InterruptionBehavior.kCancelSelf;
     }
 }
-//TODO jump wyatt

--- a/src/main/java/frc/robot/commands/PathCommand.java
+++ b/src/main/java/frc/robot/commands/PathCommand.java
@@ -41,7 +41,6 @@ public class PathCommand extends Command {
 
     @Override
     public void execute() {
-        //TODO - Why does PathWithStopDistance have specific logic to deal with the rotation?
         if(pathCommand != null){
             pathCommand.execute();
         }
@@ -49,7 +48,6 @@ public class PathCommand extends Command {
 
     @Override
     public void end(boolean interrupted) {
-        //TODO - Same question as execute()
         localizationSubsystem.removeRotationTarget();
         pathCommand.end(interrupted);
     }
@@ -58,8 +56,6 @@ public class PathCommand extends Command {
     public boolean isFinished() {
         // We want to kill the command if we're not "ready" or the path is complete.
         // In practice, not being "ready" means we don't know our orientation.
-
-        //TODO - PathWithStopDistance doesn't rely on "isFinished". Do we want to copy that here?
         return pathCommand == null || pathCommand.isFinished();
     }
 

--- a/src/main/java/frc/robot/commands/PathCommand.java
+++ b/src/main/java/frc/robot/commands/PathCommand.java
@@ -1,0 +1,68 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.positioning.Orientation;
+import frc.robot.subsystems.LocalizationSubsystem;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class PathCommand extends Command {
+
+    private final Supplier<Orientation> orientationSupplier;
+
+    private final Function<Orientation, Pose2d> positionSupplier;
+
+    private final LocalizationSubsystem localizationSubsystem;
+
+    private Command pathCommand;
+
+    public PathCommand(Supplier<Orientation> orientationSupplier, Function<Orientation, Pose2d> positionSupplier, LocalizationSubsystem localizationSubsystem) {
+        this.orientationSupplier = orientationSupplier;
+        this.positionSupplier = positionSupplier;
+        this.localizationSubsystem = localizationSubsystem;
+    }
+
+    @Override
+    public void initialize() {
+        if(pathCommand != null){
+            pathCommand.end(true);
+            pathCommand = null;
+        }
+
+        Orientation orientation = orientationSupplier.get();
+
+        if(orientation.isValid()) {
+            pathCommand = localizationSubsystem.buildPath(positionSupplier.apply(orientationSupplier.get()));
+            pathCommand.initialize();
+        }
+    }
+
+    @Override
+    public void execute() {
+        //TODO - Why does PathWithStopDistance have specific logic to deal with the rotation?
+        if(pathCommand != null){
+            pathCommand.execute();
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        //TODO - Same question as execute()
+        localizationSubsystem.removeRotationTarget();
+        pathCommand.end(interrupted);
+    }
+
+    @Override
+    public boolean isFinished() {
+        // We want to kill the command if we're not "ready" or the path is complete.
+        // In practice, not being "ready" means we don't know our orientation.
+
+        //TODO - PathWithStopDistance doesn't rely on "isFinished". Do we want to copy that here?
+        return pathCommand == null || pathCommand.isFinished();
+    }
+
+
+
+}

--- a/src/main/java/frc/robot/math/PID.java
+++ b/src/main/java/frc/robot/math/PID.java
@@ -72,9 +72,6 @@ public class PID {
         return error;
     }
 
-    //TODO add integral resetter
-    //Like that's ever happening
-
     @Override
     public String toString() {
         return "PID{" +

--- a/src/main/java/frc/robot/math/ShooterMath.java
+++ b/src/main/java/frc/robot/math/ShooterMath.java
@@ -3,6 +3,8 @@ package frc.robot.math;
 import edu.wpi.first.math.geometry.Pose2d;
 import frc.robot.Constants;
 
+import static frc.robot.positioning.FieldOrientation.getOrientation;
+
 public class ShooterMath {
     public static double getDistance3D(Pose2d robotPose) {
         return Math.sqrt(Math.pow(getDistance2D(robotPose), 2) + Math.pow(Constants.cSpeakerTargetHeight, 2));
@@ -45,10 +47,12 @@ public class ShooterMath {
     }
 
     public static double getXDiff(Pose2d robotPose) {
-        return Constants.cSpeakerTargetPos.getX() - robotPose.getX();
+//        return Constants.cSpeakerTargetPos.getX() - robotPose.getX();
+        return getOrientation().getSpeakerTargetPos().getX() - robotPose.getX();
     }
 
     public static double getYDiff(Pose2d robotPose) {
-        return Constants.cSpeakerTargetPos.getY() - robotPose.getY();
+//        return Constants.cSpeakerTargetPos.getY() - robotPose.getY();
+        return getOrientation().getSpeakerTargetPos().getY() - robotPose.getY();
     }
 }

--- a/src/main/java/frc/robot/math/ShooterMath.java
+++ b/src/main/java/frc/robot/math/ShooterMath.java
@@ -47,12 +47,14 @@ public class ShooterMath {
     }
 
     //TODO - Relies on getOrientation, which might not be initialized
+    //Safe for now
     public static double getXDiff(Pose2d robotPose) {
 //        return Constants.cSpeakerTargetPos.getX() - robotPose.getX();
         return getOrientation().getSpeakerTargetPos().getX() - robotPose.getX();
     }
 
     //TODO - Relies on getOrientation, which might not be initialized
+    //Safe for now
     public static double getYDiff(Pose2d robotPose) {
 //        return Constants.cSpeakerTargetPos.getY() - robotPose.getY();
         return getOrientation().getSpeakerTargetPos().getY() - robotPose.getY();

--- a/src/main/java/frc/robot/math/ShooterMath.java
+++ b/src/main/java/frc/robot/math/ShooterMath.java
@@ -46,11 +46,13 @@ public class ShooterMath {
         return angleDifference;
     }
 
+    //TODO - Relies on getOrientation, which might not be initialized
     public static double getXDiff(Pose2d robotPose) {
 //        return Constants.cSpeakerTargetPos.getX() - robotPose.getX();
         return getOrientation().getSpeakerTargetPos().getX() - robotPose.getX();
     }
 
+    //TODO - Relies on getOrientation, which might not be initialized
     public static double getYDiff(Pose2d robotPose) {
 //        return Constants.cSpeakerTargetPos.getY() - robotPose.getY();
         return getOrientation().getSpeakerTargetPos().getY() - robotPose.getY();

--- a/src/main/java/frc/robot/positioning/BlueOrientation.java
+++ b/src/main/java/frc/robot/positioning/BlueOrientation.java
@@ -5,6 +5,9 @@ import edu.wpi.first.math.geometry.Rotation2d;
 
 public class BlueOrientation implements Orientation{
 
+    protected BlueOrientation() {
+    }
+
     @Override
     public Pose2d getPickupPark() {
         return new Pose2d(15.25, 1.2, Rotation2d.fromDegrees(-60));

--- a/src/main/java/frc/robot/positioning/BlueOrientation.java
+++ b/src/main/java/frc/robot/positioning/BlueOrientation.java
@@ -40,7 +40,7 @@ public class BlueOrientation implements Orientation{
 
     @Override
     public Pose2d getNothingPose() {
-        return new Pose2d(69, 420, Rotation2d.fromDegrees(0));
+        return FieldOrientation.NOTHING_POSE;
     }
 
     @Override

--- a/src/main/java/frc/robot/positioning/BlueOrientation.java
+++ b/src/main/java/frc/robot/positioning/BlueOrientation.java
@@ -82,7 +82,7 @@ public class BlueOrientation implements Orientation{
 
     @Override
     public Pose2d getSpeakerTargetPos() {
-        return new Pose2d(0, 5.55, Rotation2d.fromDegrees(180));
+        return new Pose2d(0, 5.55, Rotation2d.fromDegrees(0));
     }
 
 }

--- a/src/main/java/frc/robot/positioning/BlueOrientation.java
+++ b/src/main/java/frc/robot/positioning/BlueOrientation.java
@@ -85,4 +85,9 @@ public class BlueOrientation implements Orientation{
         return new Pose2d(0, 5.55, Rotation2d.fromDegrees(0));
     }
 
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
 }

--- a/src/main/java/frc/robot/positioning/BlueOrientation.java
+++ b/src/main/java/frc/robot/positioning/BlueOrientation.java
@@ -1,0 +1,88 @@
+package frc.robot.positioning;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+
+public class BlueOrientation implements Orientation{
+
+    @Override
+    public Pose2d getPickupPark() {
+        return new Pose2d(15.25, 1.2, Rotation2d.fromDegrees(-60));
+    }
+
+    @Override
+    public Pose2d getSpeakerPark() {
+        return new Pose2d(1.4, 5.54, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getAmpPark() {
+        return new Pose2d(1.84, 7.5, Rotation2d.fromDegrees(-90));
+    }
+
+    @Override
+    public Pose2d getCenterStagePark() {
+        return new Pose2d(5.8, 4.5, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getRightStagePark() {
+        return new Pose2d(4.5, 3.5, Rotation2d.fromDegrees(60));
+    }
+
+    @Override
+    public Pose2d getLeftStagePark() {
+        return new Pose2d(4.5, 5, Rotation2d.fromDegrees(300));
+    }
+
+    @Override
+    public Pose2d getNothingPose() {
+        return new Pose2d(69, 420, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getTopCloseRing() {
+        return new Pose2d(2.89, 7, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getMidCloseRing() {
+        return new Pose2d(2.89, 5.55, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getBotCloseRing() {
+        return new Pose2d(2.89, 4.11, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getFarRing4() {
+        return  new Pose2d(8.28, 7.44, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getFarRing5() {
+        return new Pose2d(8.28, 5.78, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getFarRing6() {
+        return new Pose2d(8.28, 4.11, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getFarRing7() {
+        return new Pose2d(8.28, 2.44, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getFarRing8() {
+        return new Pose2d(8.28, 0.77, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getSpeakerTargetPos() {
+        return new Pose2d(0, 5.55, Rotation2d.fromDegrees(180));
+    }
+
+}

--- a/src/main/java/frc/robot/positioning/FieldOrientation.java
+++ b/src/main/java/frc/robot/positioning/FieldOrientation.java
@@ -8,19 +8,21 @@ public class FieldOrientation {
 
     private static final Orientation blueOrientation = new BlueOrientation();
     private static final Orientation redOrientation = new RedOrientation();
+    private static final Orientation unknownOrientation = new UnknownOrientation();
+
 
     public static Orientation getOrientation(){
         Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
         if(alliance.isEmpty()){
-            System.err.println("WARNING - NO ALLIANCE SET FROM DRIVER STATION - SETTING TO BLUE");
-            return blueOrientation;
+            System.err.println("WARNING - NO ALLIANCE SET FROM DRIVER STATION - SETTING TO UNKNOWN");
+            return unknownOrientation;
         } else if (alliance.get().equals(DriverStation.Alliance.Red)) {
             return redOrientation;
         } else if(alliance.get().equals(DriverStation.Alliance.Blue)){
             return blueOrientation;
         } else {
-            System.err.println("WARNING - UNKNOWN ALLIANCE FROM DRIVER STATION (" + alliance.get() + ") - SETTING TO BLUE");
-            return blueOrientation;
+            System.err.println("WARNING - UNKNOWN ALLIANCE FROM DRIVER STATION (" + alliance.get() + ") - SETTING TO UNKNOWN");
+            return unknownOrientation;
         }
     }
 

--- a/src/main/java/frc/robot/positioning/FieldOrientation.java
+++ b/src/main/java/frc/robot/positioning/FieldOrientation.java
@@ -1,0 +1,27 @@
+package frc.robot.positioning;
+
+import edu.wpi.first.wpilibj.DriverStation;
+
+import java.util.Optional;
+
+public class FieldOrientation {
+
+    private static final Orientation blueOrientation = new BlueOrientation();
+    private static final Orientation redOrientation = new RedOrientation();
+
+    public static Orientation getOrientation(){
+        Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
+        if(alliance.isEmpty()){
+            System.err.println("WARNING - NO ALLIANCE SET FROM DRIVER STATION - SETTING TO BLUE");
+            return blueOrientation;
+        } else if (alliance.get().equals(DriverStation.Alliance.Red)) {
+            return redOrientation;
+        } else if(alliance.get().equals(DriverStation.Alliance.Blue)){
+            return blueOrientation;
+        } else {
+            System.err.println("WARNING - UNKNOWN ALLIANCE FROM DRIVER STATION (" + alliance.get() + ") - SETTING TO BLUE");
+            return blueOrientation;
+        }
+    }
+
+}

--- a/src/main/java/frc/robot/positioning/FieldOrientation.java
+++ b/src/main/java/frc/robot/positioning/FieldOrientation.java
@@ -1,5 +1,7 @@
 package frc.robot.positioning;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 
 import java.util.Optional;
@@ -10,6 +12,8 @@ public class FieldOrientation {
     private static final Orientation redOrientation = new RedOrientation();
     private static final Orientation unknownOrientation = new UnknownOrientation();
 
+    //We should never be using this for position. But on the off-chance this gets called, make it the middle-ish of the field.
+    protected static final Pose2d NOTHING_POSE = new Pose2d(16.541/2, 7.5, Rotation2d.fromDegrees(0));
 
     public static Orientation getOrientation(){
         Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();

--- a/src/main/java/frc/robot/positioning/Orientation.java
+++ b/src/main/java/frc/robot/positioning/Orientation.java
@@ -1,0 +1,39 @@
+package frc.robot.positioning;
+
+import edu.wpi.first.math.geometry.Pose2d;
+
+public interface Orientation {
+
+    Pose2d getPickupPark();
+
+    Pose2d getSpeakerPark();
+
+    Pose2d getAmpPark();
+
+    Pose2d getCenterStagePark();
+
+    Pose2d getRightStagePark();
+
+    Pose2d getLeftStagePark();
+
+    Pose2d getNothingPose();
+
+    Pose2d getTopCloseRing();
+
+    Pose2d getMidCloseRing();
+
+    Pose2d getBotCloseRing();
+
+    Pose2d getFarRing4();
+
+    Pose2d getFarRing5();
+
+    Pose2d getFarRing6();
+
+    Pose2d getFarRing7();
+
+    Pose2d getFarRing8();
+
+    Pose2d getSpeakerTargetPos();
+
+}

--- a/src/main/java/frc/robot/positioning/Orientation.java
+++ b/src/main/java/frc/robot/positioning/Orientation.java
@@ -36,4 +36,6 @@ public interface Orientation {
 
     Pose2d getSpeakerTargetPos();
 
+    boolean isValid();
+
 }

--- a/src/main/java/frc/robot/positioning/RedOrientation.java
+++ b/src/main/java/frc/robot/positioning/RedOrientation.java
@@ -3,6 +3,9 @@ package frc.robot.positioning;
 //TODO - Switch extending BlueOrientation to implementing Orientation and fill in details
 public class RedOrientation extends BlueOrientation {
 
+    protected RedOrientation() {
+    }
+
     @Override
     public boolean isValid() {
         return false;

--- a/src/main/java/frc/robot/positioning/RedOrientation.java
+++ b/src/main/java/frc/robot/positioning/RedOrientation.java
@@ -1,0 +1,5 @@
+package frc.robot.positioning;
+
+//TODO - Switch extending BlueOrientation to implementing Orientation and fill in details
+public class RedOrientation extends BlueOrientation{
+}

--- a/src/main/java/frc/robot/positioning/RedOrientation.java
+++ b/src/main/java/frc/robot/positioning/RedOrientation.java
@@ -1,5 +1,11 @@
 package frc.robot.positioning;
 
 //TODO - Switch extending BlueOrientation to implementing Orientation and fill in details
-public class RedOrientation extends BlueOrientation{
+public class RedOrientation extends BlueOrientation {
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
 }

--- a/src/main/java/frc/robot/positioning/RedOrientation.java
+++ b/src/main/java/frc/robot/positioning/RedOrientation.java
@@ -1,14 +1,97 @@
 package frc.robot.positioning;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+
 //TODO - Switch extending BlueOrientation to implementing Orientation and fill in details
-public class RedOrientation extends BlueOrientation {
+public class RedOrientation implements Orientation {
 
     protected RedOrientation() {
     }
 
     @Override
+    public Pose2d getPickupPark() {
+        return new Pose2d(1.29, 1.20, Rotation2d.fromDegrees(60));
+    }
+
+    @Override
+    public Pose2d getSpeakerPark() {
+        return new Pose2d(15.14, 5.54, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getAmpPark() {
+        return new Pose2d(14.70, 7.50, Rotation2d.fromDegrees(-90));
+    }
+
+    @Override
+    public Pose2d getCenterStagePark() {
+        return new Pose2d(10.74, 4.5, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
+    public Pose2d getRightStagePark() {
+        return new Pose2d(12.04, 3.5, Rotation2d.fromDegrees(-120));
+    }
+
+    @Override
+    public Pose2d getLeftStagePark() {
+        return new Pose2d(12.04, 5, Rotation2d.fromDegrees(120));
+    }
+
+    @Override
+    public Pose2d getNothingPose() {
+        return FieldOrientation.NOTHING_POSE;
+    }
+
+    @Override
+    public Pose2d getTopCloseRing() {
+        return new Pose2d(13.65, 7, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getMidCloseRing() {
+        return new Pose2d(13.65, 5.55, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getBotCloseRing() {
+        return new Pose2d(13.65, 4.11, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getFarRing4() {
+        return new Pose2d(8.26, 7.44, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getFarRing5() {
+        return new Pose2d(8.26, 5.78, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getFarRing6() {
+        return new Pose2d(8.26, 4.11, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getFarRing7() {
+        return new Pose2d(8.26, 2.44, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getFarRing8() {
+        return new Pose2d(8.26, 0.77, Rotation2d.fromDegrees(180));
+    }
+
+    @Override
+    public Pose2d getSpeakerTargetPos() {
+        return new Pose2d(16.54, 5.55, Rotation2d.fromDegrees(0));
+    }
+
+    @Override
     public boolean isValid() {
-        return false;
+        return true;
     }
 
 }

--- a/src/main/java/frc/robot/positioning/UnknownOrientation.java
+++ b/src/main/java/frc/robot/positioning/UnknownOrientation.java
@@ -1,0 +1,91 @@
+package frc.robot.positioning;
+
+import edu.wpi.first.math.geometry.Pose2d;
+
+public class UnknownOrientation implements Orientation {
+
+    @Override
+    public Pose2d getPickupPark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getSpeakerPark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getAmpPark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getCenterStagePark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getRightStagePark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getLeftStagePark() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getNothingPose() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getTopCloseRing() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getMidCloseRing() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getBotCloseRing() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getFarRing4() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getFarRing5() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getFarRing6() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getFarRing7() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getFarRing8() {
+        return null;
+    }
+
+    @Override
+    public Pose2d getSpeakerTargetPos() {
+        return null;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+}

--- a/src/main/java/frc/robot/positioning/UnknownOrientation.java
+++ b/src/main/java/frc/robot/positioning/UnknownOrientation.java
@@ -4,6 +4,9 @@ import edu.wpi.first.math.geometry.Pose2d;
 
 public class UnknownOrientation implements Orientation {
 
+    protected UnknownOrientation() {
+    }
+
     @Override
     public Pose2d getPickupPark() {
         return null;

--- a/src/main/java/frc/robot/positioning/UnknownOrientation.java
+++ b/src/main/java/frc/robot/positioning/UnknownOrientation.java
@@ -39,7 +39,7 @@ public class UnknownOrientation implements Orientation {
 
     @Override
     public Pose2d getNothingPose() {
-        return null;
+        return FieldOrientation.NOTHING_POSE;
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/LocalizationSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LocalizationSubsystem.java
@@ -64,13 +64,10 @@ public class LocalizationSubsystem extends SubsystemBase {
 
     public LocalizationSubsystem(VisionSubsystem visionSubsystem, SwerveSubsystem swerveSubsystem) {
         try {
+            //We're always going to use the "blue wall" as or origin. All positions will be absolute.
+            //We'll use the FieldOrientation class to get us the right position based on our alliance.
             fieldLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile);
-            //TODO - Is this the best way to orient the field?
-            Optional<DriverStation.Alliance> allianceOption = DriverStation.getAlliance();
-            if(allianceOption.isPresent()){
-                DriverStation.Alliance alliance = allianceOption.get();
-                fieldLayout.setOrigin(alliance == DriverStation.Alliance.Blue ? AprilTagFieldLayout.OriginPosition.kBlueAllianceWallRightSide : AprilTagFieldLayout.OriginPosition.kRedAllianceWallRightSide);
-            }
+            fieldLayout.setOrigin(AprilTagFieldLayout.OriginPosition.kBlueAllianceWallRightSide);
         } catch (IOException e) {
             fieldLayout = null;
             e.printStackTrace();


### PR DESCRIPTION
Adding a framework to make the switch between blue and red alliance easy. The BlueOrientation and RedOrientation classes will contain all of the positions, and FieldOrientation::getOrientation returns the correct one based on what we read from the driver station.

All positions are going to be absolute with the blue wall being our "origin". This is a choice, we could switch our origin based on alliance. But I like this since 1) the display in shuffleboard will be accurate (it can't flip the map) and 2) it helps avoid confusion with positions that mean different things in different contexts.

BlueOrientation has the positions that were previously in Constants. We still need to update RedOrientation with the correct positions. Right now it's just returning the exact same thing as BlueOrientation.